### PR TITLE
Upgrade lexer

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -20,9 +19,7 @@ func main() {
 		text, err := reader.ReadString('\n')
 		text = strings.Replace(text, "\n", "", -1)
 
-		source := bytes.NewBufferString(text)
-
-		ast, err := gosql.Parse(source)
+		ast, err := gosql.Parse(text)
 		if err != nil {
 			panic(err)
 		}

--- a/lexer.go
+++ b/lexer.go
@@ -2,7 +2,6 @@ package gosql
 
 import (
 	"fmt"
-	"io"
 	"strings"
 )
 
@@ -52,99 +51,129 @@ type token struct {
 	loc   location
 }
 
+type cursor struct {
+	pointer uint
+	loc location
+}
+
 func (t *token) equals(other *token) bool {
 	return t.value == other.value && t.kind == other.kind
 }
 
-func (t *token) finalizeSymbol() bool {
-	switch t.value {
-	case "*":
-		break
-	case ";":
-		break
-	case "(":
-		break
-	case ")":
-		break
+type lexer func(string, cursor) (*token, cursor, bool)
+
+func lexSymbol(source string, ic cursor) (*token, cursor, bool) {
+	cur := ic
+	c := source[cur.pointer]
+
+	switch c {
+	case '\n':
+		cur.loc.line++
+		cur.loc.col = 0
+		return nil, cur, true
+	case ' ':
+		cur.loc.col++
+		cur.pointer++
+		return nil, cur, true
+	case ',':
+		fallthrough
+	case '(':
+		fallthrough
+	case ')':
+		fallthrough
+	case ';':
+		
+	case '*':
+		fallthrough
 	default:
-		return false
+		return nil, ic, false
 	}
 
-	t.kind = symbolKind
-	return true
+	cur.pointer++
+	return &token{
+		value: string(c),
+		loc: ic.loc,
+		kind: symbolKind,
+	}, cur, true
 }
 
-func (t *token) finalizeKeyword() bool {
-	switch strings.ToLower(t.value) {
-	case "select":
-		break
-	case "from":
-		break
-	case "as":
-		break
-	case "table":
-		break
-	case "create":
-		break
-	case "insert":
-		break
-	case "into":
-		break
-	case "values":
-		break
-	case "int":
-		break
-	case "text":
-		break
-	default:
-		return false
+func lexKeyword(source string, ic cursor) (*token, cursor, bool)  {
+	cur := ic
+	// Sorted manually by length
+	keywords := []keyword{
+		selectKeyword,
+		insertKeyword,
+		valuesKeyword,
+		tableKeyword,
+		fromKeyword,
+		intoKeyword,
+		textKeyword,
+		intKeyword,
+		asKeyword,
 	}
 
-	t.value = strings.ToLower(t.value)
-	t.kind = keywordKind
-	return true
+	var value []byte
+	for ; cur.pointer < uint(len(source)); cur.pointer++ {
+		value = append(value, source[cur.pointer])
+
+		// Passed than longest keyword
+		if len(value) > len(keywords[0]) {
+			return nil, ic, false
+		}
+
+		for _, keyword := range keywords {
+			// Keywords are case-insensitive
+			if strings.ToLower(string(value)) == string(keyword) {
+				cur.pointer++
+				return &token{
+					value: string(keyword),
+					kind: keywordKind,
+					loc: ic.loc,	
+				}, cur, true
+			}
+		}
+
+		cur.loc.col++
+	}
+
+	return nil, ic, false
 }
 
-func (t *token) finalizeNumeric() bool {
-	if len(t.value) == 0 {
-		return false
-	}
+func lexNumeric(source string, ic cursor) (*token, cursor, bool) {
+	cur := ic
 
 	periodFound := false
 	expMarkerFound := false
 
-	i := 0
-	for i < len(t.value) {
-		c := t.value[i]
+	for ; cur.pointer < uint(len(source)); cur.pointer++ {
+		c := source[cur.pointer]
 
 		isDigit := c >= '0' && c <= '9'
 		isPeriod := c == '.'
 		isExpMarker := c == 'e'
 
 		// Must start with a digit or period
-		if i == 0 {
+		if cur.pointer == ic.pointer {
 			if !isDigit && !isPeriod {
-				return false
+				return nil, ic, false
 			}
 
 			periodFound = isPeriod
-			i++
 			continue
 		}
 
 		if isPeriod {
 			if periodFound {
-				return false
+				return nil, ic, false
 			}
 
 			periodFound = true
-			i++
 			continue
 		}
 
 		if isExpMarker {
 			if expMarkerFound {
-				return false
+				return nil, ic, false
 			}
 
 			// No periods allowed after expMarker
@@ -152,134 +181,146 @@ func (t *token) finalizeNumeric() bool {
 			expMarkerFound = true
 
 			// expMarker must be followed by digits
-			if i == len(t.value)-1 {
-				return false
+			if cur.pointer == uint(len(source)-1) {
+				return nil, ic, false
 			}
 
-			cNext := t.value[i+1]
+			cNext := source[cur.pointer+1]
 			if cNext == '-' || cNext == '+' {
-				i++
+				cur.pointer++
 			}
 
-			i++
 			continue
 		}
 
 		if !isDigit {
-			return false
+			return nil, ic, false
+		}
+	}
+
+	return &token{
+		value: source[ic.pointer:cur.pointer],
+		loc: ic.loc,
+		kind: numericKind,
+	}, cur, true
+}
+
+func lexCharacterDelimited(source string, ic cursor, delimiter byte) (*token, cursor, bool) {
+	cur := ic
+
+	if len(source[cur.pointer:]) == 0 {
+		return nil, ic, false
+	}
+
+	if source[cur.pointer] != delimiter {
+		return nil, ic, false
+	}
+
+	cur.loc.col++
+	cur.pointer++
+
+	var value []byte
+	for ; cur.pointer < uint(len(source)); cur.pointer++ {
+		c := source[cur.pointer]
+
+		if c == delimiter {
+			// SQL escapes are via double characters, not backslash.
+			if cur.pointer + 1 >= uint(len(source)) || source[cur.pointer + 1] != delimiter {
+				return &token{
+					value: string(value),
+					loc: ic.loc,
+					kind: stringKind,
+				}, cur, true
+			} else {
+				value = append(value, delimiter)
+				cur.pointer++
+				cur.loc.col++
+			}
 		}
 
-		i++
+		value = append(value, c)
+		cur.loc.col++
 	}
 
-	t.kind = numericKind
-	return true
+	return nil, ic, false
 }
 
-func (t *token) finalizeIdentifier() bool {
-	t.kind = identifierKind
-	return true
-}
-
-func (t *token) finalizeString() bool {
-	if len(t.value) == 0 {
-		return false
+func lexIdentifier(source string, ic cursor) (*token, cursor, bool) {
+	// Handle separately if is a double-quoted identifier
+	if token, newCursor, ok := lexCharacterDelimited(source, ic, '"'); ok {
+		return token, newCursor, true
 	}
 
-	if t.value[0] == '\'' && t.value[len(t.value)-1] == '\'' {
-		t.kind = stringKind
-		t.value = t.value[1 : len(t.value)-1]
-		return true
+	cur := ic
+
+	c := source[cur.pointer]
+	// Other characters count too, big ignoring non-ascii for now
+	isAlphabetical := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+	if !isAlphabetical {
+		return nil, ic, false
 	}
+	cur.pointer++
 
-	return false
-}
+	value := []byte{c}
+	for ; cur.pointer < uint(len(source)); cur.pointer++ {
+		c = source[cur.pointer]
 
-func (t *token) finalize() bool {
-	if t.finalizeSymbol() {
-		return true
-	}
-
-	if t.finalizeKeyword() {
-		return true
-	}
-
-	if t.finalizeNumeric() {
-		return true
-	}
-
-	if t.finalizeString() {
-		return true
-	}
-
-	if t.finalizeIdentifier() {
-		return true
-	}
-
-	return false
-}
-
-func lex(source io.Reader) ([]*token, error) {
-	buf := make([]byte, 1)
-	tokens := []*token{}
-	current := token{}
-	var line uint = 0
-	var col uint = 0
-
-	for {
-		_, err := source.Read(buf)
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-
-		// Add semi-colon for EOF
-		var c byte = ';'
-		if err == nil {
-			c = buf[0]
-		}
-
-		switch c {
-		case '\n':
-			line++
-			col = 0
+		// Other characters count too, big ignoring non-ascii for now
+		isAlphabetical := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+		isNumeric := c >= '0' && c <= '9'
+		if isAlphabetical || isNumeric || c == '$' || c == '_' {
+			value = append(value, c)
+			cur.loc.col++
 			continue
-		case ' ':
-			fallthrough
-		case ',':
-			fallthrough
-		case '(':
-			fallthrough
-		case ')':
-			fallthrough
-		case ';':
-			if !current.finalize() {
-				return nil, fmt.Errorf("Unexpected token '%s' at %d:%d", current.value, current.loc.line, current.loc.col)
-			}
-
-			if current.value != "" {
-				copy := current
-				tokens = append(tokens, &copy)
-			}
-
-			if c == ';' || c == ',' || c == '(' || c == ')' {
-				tokens = append(tokens, &token{
-					loc:   location{col: col, line: line},
-					value: string(c),
-					kind:  symbolKind,
-				})
-			}
-
-			current = token{}
-			current.loc.col = col
-			current.loc.line = line
-		default:
-			current.value += string(c)
 		}
 
-		if err == io.EOF {
-			break
+		break
+	}
+
+	if len(value) == 0 {
+		return nil, ic, false
+	}
+
+	isDelimited := cur.pointer >= uint(len(source))
+	if !isDelimited {
+		_, _, isDelimited = lexSymbol(source, cur)
+	}
+
+	if isDelimited {
+		return &token{
+			// Unquoted dentifiers are case-insensitive
+			value: strings.ToLower(string(value)),
+			loc: ic.loc,
+			kind: identifierKind,
+		}, cur, true
+	}
+	
+	return nil, ic, false
+}
+
+func lexString(source string, ic cursor) (*token, cursor, bool) {
+	return lexCharacterDelimited(source, ic, '\'')
+}
+
+func lex(source string) ([]*token, error) {
+	tokens := []*token{}
+	cur := cursor{}
+
+lex:
+	for cur.pointer < uint(len(source)) {
+		lexers :=[]lexer{lexKeyword, lexSymbol, lexString, lexNumeric, lexIdentifier}
+		for _, l := range  lexers {
+			if token, newCursor, ok := l(source, cur); ok {
+				cur = newCursor
+				// Omit nil tokens for empty syntax
+				if token != nil {
+					tokens = append(tokens, token)
+				}
+				continue lex
+			}
 		}
-		col++
+
+		return nil, fmt.Errorf("Unable to lex token at %d:%d", cur.loc.line, cur.loc.col)
 	}
 
 	return tokens, nil

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -1,8 +1,8 @@
 package gosql
 
 import (
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -14,7 +14,11 @@ func TestToken_lexNumeric(t *testing.T) {
 	}{
 		{
 			number: true,
-			value:  "123",
+			value:  "105",
+		},
+		{
+			number: true,
+			value:  "105 ",
 		},
 		{
 			number: true,
@@ -69,13 +73,17 @@ func TestToken_lexNumeric(t *testing.T) {
 			number: false,
 			value:  "1ee4",
 		},
+		{
+			number: false,
+			value:  " 1",
+		},
 	}
 
 	for _, test := range tests {
 		tok, _, ok := lexNumeric(test.value, cursor{})
 		assert.Equal(t, test.number, ok, test.value)
 		if ok {
-			assert.Equal(t, test.value, tok.value, test.value)
+			assert.Equal(t, strings.TrimSpace(test.value), tok.value, test.value)
 		}
 	}
 }
@@ -91,11 +99,15 @@ func TestToken_lexString(t *testing.T) {
 		},
 		{
 			string: true,
-			value: "'a b'",
+			value:  "'a b'",
 		},
 		{
 			string: true,
-			value: "'a '' b'",
+			value:  "'a' ",
+		},
+		{
+			string: true,
+			value:  "'a '' b'",
 		},
 		// false tests
 		{
@@ -106,13 +118,18 @@ func TestToken_lexString(t *testing.T) {
 			string: false,
 			value:  "",
 		},
+		{
+			string: false,
+			value:  " 'foo'",
+		},
 	}
 
 	for _, test := range tests {
 		tok, _, ok := lexString(test.value, cursor{})
 		assert.Equal(t, test.string, ok, test.value)
 		if ok {
-			assert.Equal(t, test.value[1: len(test.value)-1], tok.value, test.value)
+			test.value = strings.TrimSpace(test.value)
+			assert.Equal(t, test.value[1:len(test.value)-1], tok.value, test.value)
 		}
 	}
 }
@@ -120,32 +137,40 @@ func TestToken_lexString(t *testing.T) {
 func TestToken_lexIdentifier(t *testing.T) {
 	tests := []struct {
 		identifier bool
-		value  string
+		value      string
 	}{
 		{
 			identifier: true,
-			value:  "abc",
+			value:      "abc",
 		},
 		{
 			identifier: true,
-			value: `" abc "`,
+			value:      "abc ",
 		},
 		{
 			identifier: true,
-			value: "a9$",
+			value:      `" abc "`,
+		},
+		{
+			identifier: true,
+			value:      "a9$",
 		},
 		// false tests
 		{
 			identifier: false,
-			value:  `"`,
+			value:      `"`,
 		},
 		{
 			identifier: false,
-			value:  "_sadsfa",
+			value:      "_sadsfa",
 		},
 		{
 			identifier: false,
-			value:  "9sadsfa",
+			value:      "9sadsfa",
+		},
+		{
+			identifier: false,
+			value:      " abc",
 		},
 	}
 
@@ -153,8 +178,9 @@ func TestToken_lexIdentifier(t *testing.T) {
 		tok, _, ok := lexIdentifier(test.value, cursor{})
 		assert.Equal(t, test.identifier, ok, test.value)
 		if ok {
+			test.value = strings.TrimSpace(test.value)
 			if test.value[0] == '"' {
-				test.value = test.value[1: len(test.value)-1]
+				test.value = test.value[1 : len(test.value)-1]
 			}
 
 			assert.Equal(t, test.value, tok.value, test.value)
@@ -165,28 +191,36 @@ func TestToken_lexIdentifier(t *testing.T) {
 func TestToken_lexKeyword(t *testing.T) {
 	tests := []struct {
 		keyword bool
-		value  string
+		value   string
 	}{
 		{
 			keyword: true,
-			value:  "select",
+			value:   "select ",
 		},
 		{
 			keyword: true,
-			value: "from",
+			value:   "from",
 		},
 		{
 			keyword: true,
-			value: "as",
+			value:   "as",
 		},
 		{
 			keyword: true,
-			value: "SELECT",
+			value:   "SELECT",
+		},
+		{
+			keyword: true,
+			value:   "into",
 		},
 		// false tests
 		{
 			keyword: false,
-			value:  "flubbrety",
+			value:   " into",
+		},
+		{
+			keyword: false,
+			value:   "flubbrety",
 		},
 	}
 
@@ -194,6 +228,7 @@ func TestToken_lexKeyword(t *testing.T) {
 		tok, _, ok := lexKeyword(test.value, cursor{})
 		assert.Equal(t, test.keyword, ok, test.value)
 		if ok {
+			test.value = strings.TrimSpace(test.value)
 			assert.Equal(t, strings.ToLower(test.value), tok.value, test.value)
 		}
 	}
@@ -214,7 +249,7 @@ func TestLex(t *testing.T) {
 					kind:  keywordKind,
 				},
 				{
-					loc:   location{col: 6, line: 0},
+					loc:   location{col: 7, line: 0},
 					value: "1",
 					kind:  numericKind,
 				},
@@ -235,39 +270,39 @@ func TestLex(t *testing.T) {
 					kind:  keywordKind,
 				},
 				{
-					loc: location{col: 12, line: 0},
+					loc:   location{col: 12, line: 0},
 					value: "users",
-					kind: identifierKind,
+					kind:  identifierKind,
 				},
 				{
-					loc:  location{col: 18, line: 0},
+					loc:   location{col: 18, line: 0},
 					value: string(valuesKeyword),
-					kind: keywordKind,
+					kind:  keywordKind,
 				},
 				{
-					loc: location{col: 25, line: 0},
+					loc:   location{col: 25, line: 0},
 					value: "(",
-					kind: symbolKind,
+					kind:  symbolKind,
 				},
 				{
-					loc: location{col: 26, line: 0},
+					loc:   location{col: 26, line: 0},
 					value: "105",
-					kind: numericKind,
+					kind:  numericKind,
 				},
 				{
-					loc: location{col: 30, line: 0},
+					loc:   location{col: 30, line: 0},
 					value: ",",
-					kind: symbolKind,
+					kind:  symbolKind,
 				},
 				{
-					loc: location{col: 32, line: 0},
+					loc:   location{col: 32, line: 0},
 					value: "233",
-					kind: numericKind,
+					kind:  numericKind,
 				},
 				{
-					loc: location{col: 33, line: 0},
+					loc:   location{col: 36, line: 0},
 					value: ")",
-					kind: symbolKind,
+					kind:  symbolKind,
 				},
 			},
 			err: nil,
@@ -281,22 +316,22 @@ func TestLex(t *testing.T) {
 					kind:  keywordKind,
 				},
 				{
-					loc:   location{col: 6, line: 0},
+					loc:   location{col: 7, line: 0},
 					value: "id",
 					kind:  identifierKind,
 				},
 				{
-					loc:   location{col: 8, line: 0},
+					loc:   location{col: 10, line: 0},
 					value: string(fromKeyword),
 					kind:  keywordKind,
 				},
 				{
-					loc:   location{col: 12, line: 0},
+					loc:   location{col: 15, line: 0},
 					value: "users",
 					kind:  identifierKind,
 				},
 				{
-					loc:   location{col: 16, line: 0},
+					loc:   location{col: 20, line: 0},
 					value: ";",
 					kind:  symbolKind,
 				},

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -1,13 +1,13 @@
 package gosql
 
 import (
-	"bytes"
 	"testing"
+	"strings"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToken_finalizeNumeric(t *testing.T) {
+func TestToken_lexNumeric(t *testing.T) {
 	tests := []struct {
 		number bool
 		value  string
@@ -72,9 +72,130 @@ func TestToken_finalizeNumeric(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tok := token{}
-		tok.value = test.value
-		assert.Equal(t, test.value, tok.value, test.number)
+		tok, _, ok := lexNumeric(test.value, cursor{})
+		assert.Equal(t, test.number, ok, test.value)
+		if ok {
+			assert.Equal(t, test.value, tok.value, test.value)
+		}
+	}
+}
+
+func TestToken_lexString(t *testing.T) {
+	tests := []struct {
+		string bool
+		value  string
+	}{
+		{
+			string: true,
+			value:  "'abc'",
+		},
+		{
+			string: true,
+			value: "'a b'",
+		},
+		{
+			string: true,
+			value: "'a '' b'",
+		},
+		// false tests
+		{
+			string: false,
+			value:  "'",
+		},
+		{
+			string: false,
+			value:  "",
+		},
+	}
+
+	for _, test := range tests {
+		tok, _, ok := lexString(test.value, cursor{})
+		assert.Equal(t, test.string, ok, test.value)
+		if ok {
+			assert.Equal(t, test.value[1: len(test.value)-1], tok.value, test.value)
+		}
+	}
+}
+
+func TestToken_lexIdentifier(t *testing.T) {
+	tests := []struct {
+		identifier bool
+		value  string
+	}{
+		{
+			identifier: true,
+			value:  "abc",
+		},
+		{
+			identifier: true,
+			value: `" abc "`,
+		},
+		{
+			identifier: true,
+			value: "a9$",
+		},
+		// false tests
+		{
+			identifier: false,
+			value:  `"`,
+		},
+		{
+			identifier: false,
+			value:  "_sadsfa",
+		},
+		{
+			identifier: false,
+			value:  "9sadsfa",
+		},
+	}
+
+	for _, test := range tests {
+		tok, _, ok := lexIdentifier(test.value, cursor{})
+		assert.Equal(t, test.identifier, ok, test.value)
+		if ok {
+			if test.value[0] == '"' {
+				test.value = test.value[1: len(test.value)-1]
+			}
+
+			assert.Equal(t, test.value, tok.value, test.value)
+		}
+	}
+}
+
+func TestToken_lexKeyword(t *testing.T) {
+	tests := []struct {
+		keyword bool
+		value  string
+	}{
+		{
+			keyword: true,
+			value:  "select",
+		},
+		{
+			keyword: true,
+			value: "from",
+		},
+		{
+			keyword: true,
+			value: "as",
+		},
+		{
+			keyword: true,
+			value: "SELECT",
+		},
+		// false tests
+		{
+			keyword: false,
+			value:  "flubbrety",
+		},
+	}
+
+	for _, test := range tests {
+		tok, _, ok := lexKeyword(test.value, cursor{})
+		assert.Equal(t, test.keyword, ok, test.value)
+		if ok {
+			assert.Equal(t, strings.ToLower(test.value), tok.value, test.value)
+		}
 	}
 }
 
@@ -97,16 +218,62 @@ func TestLex(t *testing.T) {
 					value: "1",
 					kind:  numericKind,
 				},
+			},
+			err: nil,
+		},
+		{
+			input: "insert into users values (105, 233)",
+			tokens: []token{
 				{
-					loc:   location{col: 8, line: 0},
-					value: ";",
-					kind:  symbolKind,
+					loc:   location{col: 0, line: 0},
+					value: string(insertKeyword),
+					kind:  keywordKind,
+				},
+				{
+					loc:   location{col: 7, line: 0},
+					value: string(intoKeyword),
+					kind:  keywordKind,
+				},
+				{
+					loc: location{col: 12, line: 0},
+					value: "users",
+					kind: identifierKind,
+				},
+				{
+					loc:  location{col: 18, line: 0},
+					value: string(valuesKeyword),
+					kind: keywordKind,
+				},
+				{
+					loc: location{col: 25, line: 0},
+					value: "(",
+					kind: symbolKind,
+				},
+				{
+					loc: location{col: 26, line: 0},
+					value: "105",
+					kind: numericKind,
+				},
+				{
+					loc: location{col: 30, line: 0},
+					value: ",",
+					kind: symbolKind,
+				},
+				{
+					loc: location{col: 32, line: 0},
+					value: "233",
+					kind: numericKind,
+				},
+				{
+					loc: location{col: 33, line: 0},
+					value: ")",
+					kind: symbolKind,
 				},
 			},
 			err: nil,
 		},
 		{
-			input: "SELECT id FROM users",
+			input: "SELECT id FROM users;",
 			tokens: []token{
 				{
 					loc:   location{col: 0, line: 0},
@@ -119,17 +286,17 @@ func TestLex(t *testing.T) {
 					kind:  identifierKind,
 				},
 				{
-					loc:   location{col: 9, line: 0},
+					loc:   location{col: 8, line: 0},
 					value: string(fromKeyword),
 					kind:  keywordKind,
 				},
 				{
-					loc:   location{col: 14, line: 0},
+					loc:   location{col: 12, line: 0},
 					value: "users",
 					kind:  identifierKind,
 				},
 				{
-					loc:   location{col: 20, line: 0},
+					loc:   location{col: 16, line: 0},
 					value: ";",
 					kind:  symbolKind,
 				},
@@ -139,8 +306,9 @@ func TestLex(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tokens, err := lex(bytes.NewBufferString(test.input))
+		tokens, err := lex(test.input)
 		assert.Equal(t, test.err, err, test.input)
+		assert.Equal(t, len(test.tokens), len(tokens), test.input)
 
 		for i, tok := range tokens {
 			assert.Equal(t, &test.tokens[i], tok, test.input)

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -257,6 +257,61 @@ func TestLex(t *testing.T) {
 			err: nil,
 		},
 		{
+			input: "CREATE TABLE u (id INT, name TEXT)",
+			tokens: []token{
+				{
+					loc:   location{col: 0, line: 0},
+					value: string(createKeyword),
+					kind:  keywordKind,
+				},
+				{
+					loc:   location{col: 7, line: 0},
+					value: string(tableKeyword),
+					kind:  keywordKind,
+				},
+				{
+					loc:   location{col: 13, line: 0},
+					value: "u",
+					kind:  identifierKind,
+				},
+				{
+					loc:   location{col: 15, line: 0},
+					value: "(",
+					kind:  symbolKind,
+				},
+				{
+					loc:   location{col: 16, line: 0},
+					value: "id",
+					kind:  identifierKind,
+				},
+				{
+					loc:   location{col: 19, line: 0},
+					value: "int",
+					kind:  keywordKind,
+				},
+				{
+					loc:   location{col: 22, line: 0},
+					value: ",",
+					kind:  symbolKind,
+				},
+				{
+					loc:   location{col: 24, line: 0},
+					value: "name",
+					kind:  identifierKind,
+				},
+				{
+					loc:   location{col: 29, line: 0},
+					value: "text",
+					kind:  keywordKind,
+				},
+				{
+					loc:   location{col: 33, line: 0},
+					value: ")",
+					kind:  symbolKind,
+				},
+			},
+		},
+		{
 			input: "insert into users values (105, 233)",
 			tokens: []token{
 				{

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -137,53 +137,63 @@ func TestToken_lexString(t *testing.T) {
 func TestToken_lexIdentifier(t *testing.T) {
 	tests := []struct {
 		identifier bool
+		input      string
 		value      string
 	}{
 		{
 			identifier: true,
+			input:      "abc",
 			value:      "abc",
 		},
 		{
 			identifier: true,
-			value:      "abc ",
+			input:      "abc ",
+			value:      "abc",
 		},
 		{
 			identifier: true,
-			value:      `" abc "`,
+			input:      `" abc "`,
+			value:      ` abc `,
 		},
 		{
 			identifier: true,
+			input:      "a9$",
 			value:      "a9$",
+		},
+		{
+			identifier: true,
+			input:      "userName",
+			value:      "username",
+		},
+		{
+			identifier: true,
+			input:      `"userName"`,
+			value:      "userName",
 		},
 		// false tests
 		{
 			identifier: false,
-			value:      `"`,
+			input:      `"`,
 		},
 		{
 			identifier: false,
-			value:      "_sadsfa",
+			input:      "_sadsfa",
 		},
 		{
 			identifier: false,
-			value:      "9sadsfa",
+			input:      "9sadsfa",
 		},
 		{
 			identifier: false,
-			value:      " abc",
+			input:      " abc",
 		},
 	}
 
 	for _, test := range tests {
-		tok, _, ok := lexIdentifier(test.value, cursor{})
-		assert.Equal(t, test.identifier, ok, test.value)
+		tok, _, ok := lexIdentifier(test.input, cursor{})
+		assert.Equal(t, test.identifier, ok, test.input)
 		if ok {
-			test.value = strings.TrimSpace(test.value)
-			if test.value[0] == '"' {
-				test.value = test.value[1 : len(test.value)-1]
-			}
-
-			assert.Equal(t, test.value, tok.value, test.value)
+			assert.Equal(t, test.value, tok.value, test.input)
 		}
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -388,6 +388,11 @@ func Parse(source string) (*Ast, error) {
 		return nil, err
 	}
 
+	semicolonToken := tokenFromSymbol(semicolonSymbol)
+	if len(tokens) > 0 && !tokens[len(tokens)-1].equals(&semicolonToken) {
+		tokens = append(tokens, &semicolonToken)
+	}
+
 	a := Ast{}
 	cursor := uint(0)
 	for cursor < uint(len(tokens)) {
@@ -406,7 +411,7 @@ func Parse(source string) (*Ast, error) {
 			atLeastOneSemicolon = true
 		}
 
-		if !atLeastOneSemicolon && cursor < uint(len(tokens)) {
+		if !atLeastOneSemicolon {
 			helpMessage(tokens, cursor, "Expected semi-colon delimiter between statements")
 			return nil, errors.New("Missing semi-colon between statements")
 		}

--- a/parser.go
+++ b/parser.go
@@ -3,7 +3,6 @@ package gosql
 import (
 	"errors"
 	"fmt"
-	"io"
 )
 
 func tokenFromKeyword(k keyword) token {
@@ -383,7 +382,7 @@ func parseStatement(tokens []*token, initialCursor uint, delimiter token) (*Stat
 	return nil, initialCursor, false
 }
 
-func Parse(source io.Reader) (*Ast, error) {
+func Parse(source string) (*Ast, error) {
 	tokens, err := lex(source)
 	if err != nil {
 		return nil, err
@@ -407,7 +406,7 @@ func Parse(source io.Reader) (*Ast, error) {
 			atLeastOneSemicolon = true
 		}
 
-		if !atLeastOneSemicolon {
+		if !atLeastOneSemicolon && cursor < uint(len(tokens)) {
 			helpMessage(tokens, cursor, "Expected semi-colon delimiter between statements")
 			return nil, errors.New("Missing semi-colon between statements")
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,7 +1,6 @@
 package gosql
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,7 +165,7 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ast, err := Parse(bytes.NewBufferString(test.source))
+		ast, err := Parse(test.source)
 		assert.Nil(t, err, test.source)
 		assert.Equal(t, test.ast, ast, test.source)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -19,14 +19,14 @@ func TestParse(t *testing.T) {
 						Kind: InsertKind,
 						InsertStatement: &InsertStatement{
 							table: token{
-								loc:   location{col: 11, line: 0},
+								loc:   location{col: 12, line: 0},
 								kind:  identifierKind,
 								value: "users",
 							},
 							values: &[]*expression{
 								{
 									literal: &token{
-										loc:   location{col: 25, line: 0},
+										loc:   location{col: 26, line: 0},
 										kind:  numericKind,
 										value: "105",
 									},
@@ -34,7 +34,7 @@ func TestParse(t *testing.T) {
 								},
 								{
 									literal: &token{
-										loc:   location{col: 30, line: 0},
+										loc:   location{col: 32, line: 0},
 										kind:  numericKind,
 										value: "233",
 									},
@@ -128,7 +128,7 @@ func TestParse(t *testing.T) {
 									exp: &expression{
 										kind: literalKind,
 										literal: &token{
-											loc:   location{col: 6, line: 0},
+											loc:   location{col: 7, line: 0},
 											kind:  identifierKind,
 											value: "id",
 										},
@@ -138,13 +138,13 @@ func TestParse(t *testing.T) {
 									exp: &expression{
 										kind: literalKind,
 										literal: &token{
-											loc:   location{col: 10, line: 0},
+											loc:   location{col: 11, line: 0},
 											kind:  identifierKind,
 											value: "name",
 										},
 									},
 									as: &token{
-										loc:   location{col: 18, line: 0},
+										loc:   location{col: 19, line: 0},
 										kind:  identifierKind,
 										value: "fullname",
 									},
@@ -152,7 +152,7 @@ func TestParse(t *testing.T) {
 							},
 							from: &fromItem{
 								table: &token{
-									loc:   location{col: 32, line: 0},
+									loc:   location{col: 33, line: 0},
 									kind:  identifierKind,
 									value: "users",
 								},

--- a/parser_test.go
+++ b/parser_test.go
@@ -54,31 +54,31 @@ func TestParse(t *testing.T) {
 						Kind: CreateTableKind,
 						CreateTableStatement: &CreateTableStatement{
 							name: token{
-								loc:   location{col: 12, line: 0},
+								loc:   location{col: 13, line: 0},
 								kind:  identifierKind,
 								value: "users",
 							},
 							cols: &[]*columnDefinition{
 								{
 									name: token{
-										loc:   location{col: 19, line: 0},
+										loc:   location{col: 20, line: 0},
 										kind:  identifierKind,
 										value: "id",
 									},
 									datatype: token{
-										loc:   location{col: 22, line: 0},
+										loc:   location{col: 23, line: 0},
 										kind:  keywordKind,
 										value: "int",
 									},
 								},
 								{
 									name: token{
-										loc:   location{col: 27, line: 0},
+										loc:   location{col: 28, line: 0},
 										kind:  identifierKind,
 										value: "name",
 									},
 									datatype: token{
-										loc:   location{col: 32, line: 0},
+										loc:   location{col: 33, line: 0},
 										kind:  keywordKind,
 										value: "text",
 									},
@@ -104,7 +104,7 @@ func TestParse(t *testing.T) {
 									exp: &expression{
 										kind: literalKind,
 										literal: &token{
-											loc:   location{col: 9, line: 0},
+											loc:   location{col: 10, line: 0},
 											kind:  identifierKind,
 											value: "exclusive",
 										},


### PR DESCRIPTION
The original lexer was written extremely lazily, trying to treat every lexical token the same. Among other issues, it prevented "special characters" like whitespace in strings.

This rewrites the lexer to use a similar pattern as the parser: giving control to helper functions to lex different kinds of tokens, returning a pointer to the next not lex-ed character on success.

The two major features this adds support for is:

* Support for all allowed characters in strings (including single quotes escaped by a single quote)
* Support for double quoted identifiers for case preservation, lower-casing un-quoted identifiers

This also improves the accuracy of token location tracking.

Blog post to follow.