### PR TITLE
add boolean type

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -23,6 +23,7 @@ const (
 	valuesKeyword keyword = "values"
 	intKeyword    keyword = "int"
 	textKeyword   keyword = "text"
+	boolKeyword   keyword = "boolean"
 	whereKeyword  keyword = "where"
 	andKeyword    keyword = "and"
 	orKeyword     keyword = "or"
@@ -182,6 +183,7 @@ func lexKeyword(source string, ic cursor) (*token, cursor, bool) {
 		fromKeyword,
 		intoKeyword,
 		textKeyword,
+		boolKeyword,
 		intKeyword,
 		andKeyword,
 		orKeyword,

--- a/memory.go
+++ b/memory.go
@@ -344,6 +344,8 @@ func (mb *MemoryBackend) CreateTable(crt *CreateTableStatement) error {
 			dt = IntType
 		case "text":
 			dt = TextType
+		case "boolean":
+			dt = BoolType
 		default:
 			return ErrInvalidDatatype
 		}


### PR DESCRIPTION
Hey!

Added support for type `BOOLEAN`.  All changes have been formatted and all tests pass.

---

### Details

The implementation seemed to be partially complete before I started, as `BoolType` is already defined and used throughout memory.go.

After adding `boolKeyword` to lexer.go and `case "boolean"` to `func (mb *MemoryBackend)  CreateTable` in memory.go, I am able to run statements in the REPL like this:

```
Welcome to gosql.
# CREATE TABLE facts (fact TEXT, is_true BOOLEAN);
ok
# INSERT INTO facts VALUES ('the sun is purple', false);
ok
# SELECT fact, is_true FROM facts;
        fact        | is_true  
--------------------+----------
  the sun is purple | false    
(1 result)
ok
```

---

Am I missing any implementation details? As far as I can tell the type is now supported.  

-- Parker
