### PR TITLE
Add \q to exit, fix exit/quit not working sometimes, small optimization

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,8 +101,8 @@ repl:
 			continue repl
 		}
 
-		trimmedLine := strings.Trim(line, " ")
-		if trimmedLine == "quit" || trimmedLine == "exit" || trimmedLine == "\\q" {
+		trimmedLine := strings.TrimRight(line, " ")
+		if trimmedLine == "quit" || trimmedLine == "exit" || strings.TrimLeft(trimmedLine, " ") == "\\q" {
 			break
 		}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,17 +24,17 @@ func doSelect(mb gosql.Backend, slct *gosql.SelectStatement) error {
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	header := make([]string, len(results.Columns))
-	for i, col := range results.Columns {
-		header[i] = col.Name
+	header := []string{}
+	for _, col := range results.Columns {
+		header = append(header, col.Name)
 	}
 	table.SetHeader(header)
 	table.SetAutoFormatHeaders(false)
 
-	rows := make([][]string, len(results.Rows))
-	for i, result := range results.Rows {
-		row := make([]string, len(result))
-		for j, cell := range result {
+	rows := [][]string{}
+	for _, result := range results.Rows {
+		row := []string{}
+		for i, cell := range result {
 			typ := results.Columns[i].Type
 			s := ""
 			switch typ {
@@ -49,10 +49,10 @@ func doSelect(mb gosql.Backend, slct *gosql.SelectStatement) error {
 				}
 			}
 
-			row[j] = s
+			row = append(row, s)
 		}
 
-		rows[i] = row
+		rows = append(rows, row)
 	}
 
 	table.SetBorder(false)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -101,7 +101,6 @@ repl:
 			continue repl
 		}
 
-		// basic commands ignore whitespace
 		trimmedLine := strings.Trim(line, " ")
 		if trimmedLine == "quit" || trimmedLine == "exit" || trimmedLine == "\\q" {
 			break


### PR DESCRIPTION
Fixes an oversight in the previous PR: 'quit' and 'exit' ignore trailing whitespace on postgres, so now they do so here as well. Since \q is also a valid way to exit in postgres I've added it (\q ignores all whitespace)