### PR TITLE
style: no need to check len(value)

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -447,10 +447,6 @@ func lexIdentifier(source string, ic cursor) (*Token, cursor, bool) {
 		break
 	}
 
-	if len(value) == 0 {
-		return nil, ic, false
-	}
-
 	return &Token{
 		// Unquoted identifiers are case-insensitive
 		Value: strings.ToLower(string(value)),


### PR DESCRIPTION
Since `len(value)` must be greater than or equal to 1, there is no need to check `len(value)` again.